### PR TITLE
Feature/script temp file

### DIFF
--- a/mssql-scripter/mssql/common/json_rpc_client.py
+++ b/mssql-scripter/mssql/common/json_rpc_client.py
@@ -8,7 +8,7 @@ import logging
 from queue import Queue
 import threading
 
-logger = logging.getLogger('common.json_rpc_client')
+logger = logging.getLogger('mssql-scripter.common.json_rpc_client')
 
 
 class Json_Rpc_Client(object):

--- a/mssql-scripter/mssql/contracts/scripting.py
+++ b/mssql-scripter/mssql/contracts/scripting.py
@@ -32,7 +32,8 @@ class Scripting_Request(Request):
         """
             Submits scripting request via json rpc client with formatted parameters and id.
         """
-        logger.info('Submitting scripting request id: {0}'.format(self.id))
+        logger.info('Submitting scripting request id: {} with targetfile: {}'.format(self.id, self.params.file_path))
+        
         self.json_rpc_client.submit_request(
             self.METHOD_NAME, self.params.format(), self.id)
 

--- a/mssql-scripter/mssql/scripter/__init__.py
+++ b/mssql-scripter/mssql/scripter/__init__.py
@@ -7,7 +7,6 @@ import os
 import platform
 import site
 import sys
-import tempfile
 
 
 # Check repo if in dev mode.
@@ -87,7 +86,7 @@ def initialize_parser():
     parser.add_argument(
         '--FilePath',
         help='target file to store the script of the database',
-        default=tempfile.NamedTemporaryFile(prefix='mssqlscripter_', delete=False).name)
+        default=None)
 
     # General boolean Scripting Options
     parser.add_argument('--ANSIPadding', help='', default=False)

--- a/mssql-scripter/mssql/scripter/main.py
+++ b/mssql-scripter/mssql/scripter/main.py
@@ -7,7 +7,9 @@ import io
 import os
 import subprocess
 import sys
+import tempfile
 
+import scripter_logging
 import mssql.scripter as scripter
 from mssql.sql_tools_client import Sql_Tools_Client
 
@@ -20,6 +22,12 @@ def main(args):
 
     parser = scripter.initialize_parser()
     parameters = parser.parse_args(args)
+
+    temp_file_path = None
+    if (not parameters.FilePath):
+        # Generate and track the temp file.
+        temp_file_path = tempfile.NamedTemporaryFile(prefix='mssqlscripter_', delete=False).name
+        parameters.FilePath = temp_file_path
 
     sql_tools_service_path = scripter.get_native_tools_service_path()
 
@@ -61,8 +69,8 @@ def main(args):
             sys.stdout.write(line)
     
     # Remove the temp file if we generated one.
-    if (parameters.FilePath.startswith('mssqlscripter_')):
-        os.remove(parameters.FilePath)
+    if (temp_file_path):
+        os.remove(temp_file_path)
 
 
     # May need to add a timer here


### PR DESCRIPTION
if the user does not specify a target file, we script to a temp file and delete it afterwards.
temp files are prefixed by mssqlscripter_ to follow similar convention by sqltoolsservice logs.