### PR TITLE
Fix for script request not changing state when request returns a erro…

### DIFF
--- a/mssqlscripter/jsonrpc/contracts/scripting.py
+++ b/mssqlscripter/jsonrpc/contracts/scripting.py
@@ -50,10 +50,11 @@ class ScriptingRequest(Request):
             if response:
                 # Decode response to either response or event type.
                 decoded_response = self.decoder.decode_response(response)
+                
                 logger.debug(
                     u'Scripting request received response: {}'.format(decoded_response))
-                if isinstance(decoded_response, ScriptCompleteEvent
-                              or isinstance(decoded_response, ScriptErrorEvent)):
+                if (isinstance(decoded_response, ScriptCompleteEvent) or 
+                    isinstance(decoded_response, ScriptErrorEvent)):
                     self.finished = True
                     self.json_rpc_client.request_finished(self.id)
 


### PR DESCRIPTION
While testing what happens when a incorrect connection string is supplied, I discovered that the scripting request state does not get changed to finished; therefore, running the request in a infinite loop looking for more messages.

Fix: There was a parenthesis that got lost during the refactoring.