### PR TITLE
Feature/travis ci optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: True
 language: python
 matrix:
   include:
-      - os: osx
+    - os: osx
       language: generic
       env: TOXENV=py36
     - os: osx


### PR DESCRIPTION
Updating travis.yml to only brew update and install python 3 if we are running against osx and python 3.6

This is to reduce the redundant step for when targeting python 2.7 in osx since it comes preinstalled.