### PR TITLE
Ron/remove win64

### DIFF
--- a/build.py
+++ b/build.py
@@ -152,7 +152,6 @@ if __name__ == '__main__':
     supported_platforms = [
         'win32',
         'win_amd64',
-        'win64',
         'macosx_10_11_intel',
         'manylinux1_x86_64',
         'manylinux1_i686']

--- a/mssql-scripter.pyproj
+++ b/mssql-scripter.pyproj
@@ -66,13 +66,10 @@
     <Compile Include="mssqlscripter\tests\test_sqltoolsclient.py" />
     <Compile Include="mssqlscripter\__init__.py" />
     <Compile Include="mssqlscripter\__main__.py" />
-    <Compile Include="mssqltoolsservice\buildwheels.py" />
-    <Compile Include="mssqltoolsservice\mssqltoolsservice\__init__.py" />
-    <Compile Include="mssqltoolsservice\setup.py" />
-    <Compile Include="register_upload.py" />
+    <Compile Include="mssqlscripter\mssqltoolsservice\__init__.py" />
+    <Compile Include="mssqlscripter\mssqltoolsservice\external.py" />
     <Compile Include="setup.py" />
     <Compile Include="utility.py" />
-    <Compile Include="verify_packaging.py" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="doc\" />
@@ -83,8 +80,7 @@
     <Folder Include="mssqlscripter\jsonrpc\contracts\tests\scripting_baselines" />
     <Folder Include="mssqlscripter\jsonrpc\tests" />
     <Folder Include="mssqlscripter\tests" />
-    <Folder Include="mssqltoolsservice\" />
-    <Folder Include="mssqltoolsservice\mssqltoolsservice\" />
+    <Folder Include="mssqlscripter\mssqltoolsservice\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/mssqlscripter/mssqltoolsservice/external.py
+++ b/mssqlscripter/mssqltoolsservice/external.py
@@ -21,8 +21,7 @@ SUPPORTED_PLATFORMS = {
     'manylinux1_x86_64': SQLTOOLSSERVICE_BASE + 'manylinux1/' + 'Microsoft.SqlTools.ServiceLayer-linux-x64-netcoreapp2.0.tar.gz',
     'manylinux1_i686': SQLTOOLSSERVICE_BASE + 'manylinux1/' + 'Microsoft.SqlTools.ServiceLayer-linux-x64-netcoreapp2.0.tar.gz',
     'macosx_10_11_intel': SQLTOOLSSERVICE_BASE + 'macosx_10_11_intel/' + 'Microsoft.SqlTools.ServiceLayer-osx-x64-netcoreapp2.0.tar.gz',
-    'win_amd64': SQLTOOLSSERVICE_BASE + 'win64/' + 'Microsoft.SqlTools.ServiceLayer-win-x64-netcoreapp2.0.zip',
-    'win64': SQLTOOLSSERVICE_BASE + 'win64/' + 'Microsoft.SqlTools.ServiceLayer-win-x64-netcoreapp2.0.zip',
+    'win_amd64': SQLTOOLSSERVICE_BASE + 'winamd64/' + 'Microsoft.SqlTools.ServiceLayer-win-x64-netcoreapp2.0.zip',
     'win32': SQLTOOLSSERVICE_BASE + 'win32/' + 'Microsoft.SqlTools.ServiceLayer-win-x86-netcoreapp2.0.zip'
 }
 
@@ -39,7 +38,7 @@ def copy_sqltoolsservice(platform):
     if not platform or platform not in SUPPORTED_PLATFORMS:
         print('{} is not supported.'.format(platform))
         print('Please provide a valid platform flag.' +
-              '[win32, win_amd64, win64, manylinux1_x86_64, manylinux1_i686, macosx_10_11_intel]')
+              '[win32, win_amd64, manylinux1_x86_64, manylinux1_i686, macosx_10_11_intel]')
         sys.exit(1)
 
     copy_file_path = SUPPORTED_PLATFORMS[platform]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     PYTHONIOENCODING=utf-8
 
 deps=
-    -r dev_requirements.txt
+    -rdev_requirements.txt
 
 install_commands = 
 commands=


### PR DESCRIPTION
win64 is not a supported platform tag. 
Pypi prevents this tag from uploading and I've verified pip has win_amd64 as the supported tag locally.
Also seems like most popular packages only have win_am64 for that plat/arch. i.e Numpy