### PR TITLE
Environment Variables example (Windows)

### DIFF
--- a/doc/usage_guide.md
+++ b/doc/usage_guide.md
@@ -233,10 +233,25 @@ Note this example is for Linux and macOS usage.
 You can set environment variables for your connection string through the following steps:
 
 
+    # (linux/bash)
     # set environment variable MSSQL_SCRIPTER_CONNECTION_STRING with a connection string.
     $ export MSSQL_SCRIPTER_CONNECTION_STRING='Server=myserver;Database=mydb;User Id=myuser;Password=mypassword;'
     $ mssql-scripter
 
+    # (linux/bash)
     # set environment variable MSSQL_SCRIPTER_PASSWORD so no password input is required.
     $ export MSSQL_SCRIPTER_PASSWORD='[PLACEHOLDER]'
     $ mssql-scripter -S localhost -d AdventureWorks -U sa
+
+    # (windows)
+    # set environment variable MSSQL_SCRIPTER_CONNECTION_STRING with a connection string.
+    setx MSSQL_SCRIPTER_CONNECTION_STRING 'Server=myserver;Database=mydb;User Id=myuser;Password=mypassword;'
+    # note: you must start a new PS session for the change to take effect
+    mssql-scripter
+    
+    # (windows)
+    # set environment variable MSSQL_SCRIPTER_PASSWORD so no password input is required.
+    setx MSSQL_SCRIPTER_PASSWORD mypassword
+    # note: you must start a new PS session for the change to take effect
+    $ mssql-scripter -S localhost -d AdventureWorks -U sa
+   

--- a/doc/usage_guide.md
+++ b/doc/usage_guide.md
@@ -245,13 +245,10 @@ You can set environment variables for your connection string through the followi
 
     # (windows)
     # set environment variable MSSQL_SCRIPTER_CONNECTION_STRING with a connection string.
-    setx MSSQL_SCRIPTER_CONNECTION_STRING 'Server=myserver;Database=mydb;User Id=myuser;Password=mypassword;'
-    # note: you must start a new PS session for the change to take effect
+    $Env:MSSQL_SCRIPTER_CONNECTION_STRING = 'Server=myserver;Database=mydb;User Id=myuser;Password=mypassword;'
     mssql-scripter
     
     # (windows)
     # set environment variable MSSQL_SCRIPTER_PASSWORD so no password input is required.
-    setx MSSQL_SCRIPTER_PASSWORD mypassword
-    # note: you must start a new PS session for the change to take effect
+    $Env:MSSQL_SCRIPTER_PASSWORD = "placeholder"
     $ mssql-scripter -S localhost -d AdventureWorks -U sa
-   

--- a/doc/usage_guide.md
+++ b/doc/usage_guide.md
@@ -251,4 +251,4 @@ You can set environment variables for your connection string through the followi
     # (windows)
     # set environment variable MSSQL_SCRIPTER_PASSWORD so no password input is required.
     $Env:MSSQL_SCRIPTER_PASSWORD = "placeholder"
-    $ mssql-scripter -S localhost -d AdventureWorks -U sa
+    mssql-scripter -S localhost -d AdventureWorks -U sa


### PR DESCRIPTION
The included examples for "Environment Variables" do not work on Windows. This change adds the equivalent commands on Windows using ~~setx~~ powershell `$Env:` variables.